### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shlink coding standard
 
-This repository provides a [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) ruleset with the rules used by shlink PHP projects.
+This repository provides a [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) ruleset with the rules used by shlink PHP projects.
 
 ## Usage
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932